### PR TITLE
Add support for strings parsing

### DIFF
--- a/Arrow.swift
+++ b/Arrow.swift
@@ -10,15 +10,20 @@ import Foundation
 
 public typealias JSON = AnyObject
 
-private let dateFormater = NSDateFormatter()
+private let dateFormatter = NSDateFormatter()
+
+private var useReferenceDate = false
 
 public class Arrow {
     public class func setDateFormat(format:String) {
-        dateFormater.dateFormat = format
+        dateFormatter.dateFormat = format
+    }
+    public class func setUseTimeIntervalSinceReferenceDate(ref:Bool) {
+        useReferenceDate = ref
     }
 }
 
-// MARK : -  Parse Default swift Types
+// MARK: - Parse Default swift Types
 
 infix operator <-- {}
 public func <-- <T>(inout left: T, right: AnyObject?) {
@@ -34,8 +39,7 @@ public func <-- <T>(inout left: T?, right: AnyObject?) {
     }
 }
 
-
-// MARK : - Parse Custom Types
+// MARK: - Parse Custom Types
 
 public protocol ArrowParsable {
     init(json: JSON)
@@ -55,19 +59,128 @@ public func <== <T:ArrowParsable>(inout left:T?, right: AnyObject?) {
     }
 }
 
+// MARK: - Parse Numeric Types
 
-// MARK : - NSDate Parsing 
+public func <--(inout left: Int, right: AnyObject?) {
+    if let v = right as? Int {
+        left = v
+    } else if let s = right as? String, let v = Int(s) {
+        left = v
+    }
+}
+
+public func <--(inout left: Int?, right: AnyObject?) {
+    if let v = right as? Int {
+        left = v
+    } else if let s = right as? String, let v = Int(s) {
+        left = v
+    }
+}
+
+public func <--(inout left: UInt, right: AnyObject?) {
+    if let v = right as? UInt {
+        left = v
+    } else if let s = right as? String, let v = UInt(s) {
+        left = v
+    }
+}
+
+public func <--(inout left: UInt?, right: AnyObject?) {
+    if let v = right as? UInt {
+        left = v
+    } else if let s = right as? String, let v = UInt(s) {
+        left = v
+    }
+}
+
+public func <--(inout left: Bool, right: AnyObject?) {
+    if let v = right as? Bool {
+        left = v
+    } else if let s = right as? String, let v = Int(s) {
+        left = Bool(v)
+    }
+}
+
+public func <--(inout left: Bool?, right: AnyObject?) {
+    if let v = right as? Bool {
+        left = v
+    } else if let s = right as? String, let v = Int(s) {
+        left = Bool(v)
+    }
+}
+
+public func <--(inout left: Double, right: AnyObject?) {
+    if let v = right as? Double {
+        left = v
+    } else if let s = right as? String, let v = Double(s) {
+        left = v
+    }
+}
+
+public func <--(inout left: Double?, right: AnyObject?) {
+    if let v = right as? Double {
+        left = v
+    } else if let s = right as? String, let v = Double(s) {
+        left = v
+    }
+}
+
+public func <--(inout left: Float, right: AnyObject?) {
+    if let v = right as? Float {
+        left = v
+    } else if let s = right as? String, let v = Float(s) {
+        left = v
+    }
+}
+
+public func <--(inout left: Float?, right: AnyObject?) {
+    if let v = right as? Float {
+        left = v
+    } else if let s = right as? String, let v = Float(s) {
+        left = v
+    }
+}
+
+public func <--(inout left: CGFloat, right: AnyObject?) {
+    if let v = right as? CGFloat {
+        left = v
+    } else if let s = right as? String, let v = CGFloat.NativeType(s) {
+        left = CGFloat(v)
+    }
+}
+
+public func <--(inout left: CGFloat?, right: AnyObject?) {
+    if let v = right as? CGFloat {
+        left = v
+    } else if let s = right as? String, let v = CGFloat.NativeType(s) {
+        left = CGFloat(v)
+    }
+}
+
+// MARK: - NSDate Parsing
 
 // Override Arrow Operator to catch NSDate Mapping and apply our transformation
 public func <-- (inout left: NSDate, right: AnyObject?) {
-    if let s = right as? String, let date = dateFormater.dateFromString(s)  {
-        left = date
+    if let s = right as? String {
+        if let date = dateFormatter.dateFromString(s)  {
+            left = date
+        } else if let t = NSTimeInterval(s) {
+            left = useReferenceDate ? NSDate(timeIntervalSinceReferenceDate: t) : NSDate(timeIntervalSince1970: t)
+        }
+    } else if let t = right as? NSTimeInterval {
+        left = useReferenceDate ? NSDate(timeIntervalSinceReferenceDate: t) : NSDate(timeIntervalSince1970: t)
     }
 }
 
 public func <-- (inout left: NSDate?, right: AnyObject?) {
-    if let s = right as? String, let date = dateFormater.dateFromString(s)  {
-        left = date
+    if let s = right as? String {
+        if let date = dateFormatter.dateFromString(s)  {
+            left = date
+        } else if let t = NSTimeInterval(s) {
+            left = useReferenceDate ? NSDate(timeIntervalSinceReferenceDate: t) : NSDate(timeIntervalSince1970: t)
+        }
+    } else if let t = right as? NSTimeInterval {
+        left = useReferenceDate ? NSDate(timeIntervalSinceReferenceDate: t) : NSDate(timeIntervalSince1970: t)
     }
 }
 

--- a/ArrowExample/ArrowExample/Profile.json
+++ b/ArrowExample/ArrowExample/Profile.json
@@ -1,6 +1,7 @@
 {
     "id": 15678,
     "created_at" : "2013-06-07T16:38:40+02:00",
+    "created_at_timestamp" : "392308720",
     "name": "Francky",
     "stats": {
         "numberOfFriends": 163,

--- a/ArrowExample/ArrowTests/ArrowTests.swift
+++ b/ArrowExample/ArrowTests/ArrowTests.swift
@@ -18,6 +18,7 @@ class ArrowTests: XCTestCase {
     override func setUp() {
         super.setUp()
         Arrow.setDateFormat("yyyy-MM-dd'T'HH:mm:ssZZZZZ")
+        Arrow.setUseTimeIntervalSinceReferenceDate(true)
         let json:JSON = jsonForName("Profile")!
         profile = Profile(json: json)
     }
@@ -35,7 +36,9 @@ class ArrowTests: XCTestCase {
         let df = NSDateFormatter()
         df.dateFormat = "yyyy-MM-dd'T'HH:mm:ssZZZZZ"
         let date = df.dateFromString("2013-06-07T16:38:40+02:00")!
+        let timestamp: NSTimeInterval = 392308720
         XCTAssertEqualWithAccuracy(date.timeIntervalSinceReferenceDate, profile!.createdAt.timeIntervalSinceReferenceDate, accuracy: 0.1)
+        XCTAssertEqualWithAccuracy(timestamp, profile!.optionalDate!.timeIntervalSinceReferenceDate, accuracy: 0.1)
     }
     
     func testParsingString() {

--- a/ArrowExample/ArrowTests/Profile+Arrow.swift
+++ b/ArrowExample/ArrowTests/Profile+Arrow.swift
@@ -15,10 +15,12 @@ extension Profile:ArrowParsable {
         identifier <-- json["id"]
         createdAt <-- json["created_at"]
         name <-- json["name"]
-        optionalName = ""
+        optionalName = nil
         optionalName <-- json["name"]
         stats <== json["stats"]
-        optionalStats = Stats()
+        optionalStats = nil
         optionalStats <== json["stats"]
+        optionalDate = nil
+        optionalDate <-- json["created_at_timestamp"]
     }
 }

--- a/ArrowExample/ArrowTests/Profile.json
+++ b/ArrowExample/ArrowTests/Profile.json
@@ -1,6 +1,7 @@
 {
     "id": 15678,
     "created_at" : "2013-06-07T16:38:40+02:00",
+    "created_at_timestamp" : "392308720",
     "name": "Francky",
     "stats": {
         "numberOfFriends": 163,

--- a/ArrowExample/ArrowTests/Profile.swift
+++ b/ArrowExample/ArrowTests/Profile.swift
@@ -15,4 +15,5 @@ struct Profile {
     var optionalName:String?
     var stats = Stats()
     var optionalStats:Stats?
+    var optionalDate:NSDate?
 }

--- a/README.md
+++ b/README.md
@@ -49,10 +49,11 @@ Json mapping code becomes **concise** and **maintainable** ❤️
 
 
 ## What
-- [x] Simple & Lightweight (~50lines)
+- [x] Simple & Lightweight (<200lines)
 - [x] Pure Swift
 - [x] Leaves your models clean
 - [x] Implicitly casts JSON values to the right types in your model
+- [x] Converts string values to numeric types in your model
 - [x] Does not crash if JSON key is not there, nor returns nil, it simply doesn't do anything
 - [x] NSDate Parsing
 - [x] No overly complex obscure functional chaining operator overloading voodoo magic ?==:>>><> 😅
@@ -181,7 +182,13 @@ Sure, just set your date format once and you're done.
 
 ```swift
 // Configure NSDate Parsing
-Arrow.dateFormat("yyyy-MM-dd'T'HH:mm:ssZZZZZ")
+Arrow.setDateFormat("yyyy-MM-dd'T'HH:mm:ssZZZZZ")
+Arrow.setUseTimeIntervalSinceReferenceDate(true)
+
+// Dates can be parsed form custom date format or timestamp
+let json = ["date": "2013-06-07T16:38:40+02:00", "timestamp": 392308720]
+date1 <-- json["date"]
+date2 <-- json["timestamp"]
 ```
 ## Acknoledgments
 This wouldn't exist without YannickDot (https://github.com/YannickDot) and Damien-nd (https://github.com/damien-nd)


### PR DESCRIPTION
Hey, don't know if this PR is appropriate for the original idea of the lib, but for me it is required to be able to parse numbers represented as strings in JSON to plain numeric types.

Consider the following JSON:

``` json
{ "id": "42" }
```

The current implementation fails to parse this case:

``` swift
int <-- json["id"] // does nothing
```

I added support for parsing basic numeric types (`Int`, `UInt`, `Bool`, `Double`, `Float`, `CGFloat` and corresponding optionals) from string, so the above no longer fails:

``` swift
int <-- json["id"] // = 42
double <-- json["id"] // = 42.0
```

Also added the ability to parse `NSDate` from timestamp (number or string):

``` swift
let json = ["timestamp": 392308720]
date <-- json["timestamp"]
```

Please feel free to modify this as you see fit :)
