### PR TITLE
Noinit

### DIFF
--- a/Arrow.swift
+++ b/Arrow.swift
@@ -83,20 +83,25 @@ public func <-- <T>(inout left: [T]?, right: AnyObject?) {
 // MARK: - Parse Custom Types
 
 public protocol ArrowParsable {
-    init(json: JSON)
+    init()
+    mutating func deserialize(json:JSON)
 }
 
 infix operator <== {}
 public func <== <T:ArrowParsable>(inout left:T, right: AnyObject?) {
     if let r: AnyObject = right {
-        left = T.self(json:r)
+        var t = T.self()
+        t.deserialize(r)
+        left = t
     }
 }
 
 // Support optional Data
 public func <== <T:ArrowParsable>(inout left:T?, right: AnyObject?) {
     if let r: AnyObject = right {
-        left = T.self(json:r)
+        var t = T.self()
+        t.deserialize(r)
+        left = t
     }
 }
 
@@ -104,13 +109,21 @@ public func <== <T:ArrowParsable>(inout left:T?, right: AnyObject?) {
 
 public func <== <T:ArrowParsable>(inout left:[T], right: AnyObject?) {
     if let a = right as? [AnyObject] {
-        left = a.map { T(json: $0) }
+        left = a.map {
+            var t = T.self()
+            t.deserialize($0)
+            return t
+        }
     }
 }
 
 public func <== <T:ArrowParsable>(inout left:[T]?, right: AnyObject?) {
     if let a = right as? [AnyObject] {
-        left = a.map { T(json: $0) }
+        left = a.map {
+            var t = T.self()
+            t.deserialize($0)
+            return t
+        }
     }
 }
 

--- a/ArrowExample/ArrowExample.xcodeproj/project.pbxproj
+++ b/ArrowExample/ArrowExample.xcodeproj/project.pbxproj
@@ -11,6 +11,11 @@
 		994243AD1CAA4F3E00B5DB6C /* Profile.swift in Sources */ = {isa = PBXBuildFile; fileRef = 994243AC1CAA4F3E00B5DB6C /* Profile.swift */; };
 		994243AF1CAA4F4D00B5DB6C /* Stats.swift in Sources */ = {isa = PBXBuildFile; fileRef = 994243AE1CAA4F4D00B5DB6C /* Stats.swift */; };
 		994243B11CAA502A00B5DB6C /* Profile.json in Resources */ = {isa = PBXBuildFile; fileRef = 994243B01CAA502A00B5DB6C /* Profile.json */; };
+		999B90681CBE4C2100C4B46A /* User.swift in Sources */ = {isa = PBXBuildFile; fileRef = 999B90671CBE4C2100C4B46A /* User.swift */; };
+		999B906A1CBE4C3D00C4B46A /* User+JSON.swift in Sources */ = {isa = PBXBuildFile; fileRef = 999B90691CBE4C3D00C4B46A /* User+JSON.swift */; };
+		99BD0D8D1CBE511A00995392 /* Profile+JSON.swift in Sources */ = {isa = PBXBuildFile; fileRef = 99BD0D8C1CBE511A00995392 /* Profile+JSON.swift */; };
+		99BD0D8F1CBE514A00995392 /* Stats+JSON.swift in Sources */ = {isa = PBXBuildFile; fileRef = 99BD0D8E1CBE514A00995392 /* Stats+JSON.swift */; };
+		99BD0D921CBE518D00995392 /* PhoneNumber+JSON.swift in Sources */ = {isa = PBXBuildFile; fileRef = 99BD0D911CBE518D00995392 /* PhoneNumber+JSON.swift */; };
 		99C292C31B24AD4A0008C32B /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 99C292C21B24AD4A0008C32B /* AppDelegate.swift */; };
 		99C292D91B24AD4A0008C32B /* ArrowExampleTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 99C292D81B24AD4A0008C32B /* ArrowExampleTests.swift */; };
 		99C292EC1B24AD5E0008C32B /* Arrow.h in Headers */ = {isa = PBXBuildFile; fileRef = 99C292EB1B24AD5E0008C32B /* Arrow.h */; settings = {ATTRIBUTES = (Public, ); }; };
@@ -76,6 +81,11 @@
 		994243AC1CAA4F3E00B5DB6C /* Profile.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Profile.swift; sourceTree = "<group>"; };
 		994243AE1CAA4F4D00B5DB6C /* Stats.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Stats.swift; sourceTree = "<group>"; };
 		994243B01CAA502A00B5DB6C /* Profile.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = Profile.json; sourceTree = "<group>"; };
+		999B90671CBE4C2100C4B46A /* User.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = User.swift; sourceTree = "<group>"; };
+		999B90691CBE4C3D00C4B46A /* User+JSON.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "User+JSON.swift"; sourceTree = "<group>"; };
+		99BD0D8C1CBE511A00995392 /* Profile+JSON.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "Profile+JSON.swift"; sourceTree = "<group>"; };
+		99BD0D8E1CBE514A00995392 /* Stats+JSON.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "Stats+JSON.swift"; sourceTree = "<group>"; };
+		99BD0D911CBE518D00995392 /* PhoneNumber+JSON.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "PhoneNumber+JSON.swift"; sourceTree = "<group>"; };
 		99C292BD1B24AD4A0008C32B /* ArrowExample.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = ArrowExample.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		99C292C11B24AD4A0008C32B /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		99C292C21B24AD4A0008C32B /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
@@ -130,6 +140,16 @@
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
+		99BD0D891CBE50EB00995392 /* Mapping */ = {
+			isa = PBXGroup;
+			children = (
+				99BD0D8C1CBE511A00995392 /* Profile+JSON.swift */,
+				99BD0D8E1CBE514A00995392 /* Stats+JSON.swift */,
+				99BD0D911CBE518D00995392 /* PhoneNumber+JSON.swift */,
+			);
+			name = Mapping;
+			sourceTree = "<group>";
+		};
 		99C292B41B24AD4A0008C32B = {
 			isa = PBXGroup;
 			children = (
@@ -158,6 +178,8 @@
 				99C292C21B24AD4A0008C32B /* AppDelegate.swift */,
 				99C293091B24AE320008C32B /* Usage.swift */,
 				99C2930D1B24AE320008C32B /* Models.swift */,
+				999B90671CBE4C2100C4B46A /* User.swift */,
+				999B90691CBE4C3D00C4B46A /* User+JSON.swift */,
 				99C293121B24AF6A0008C32B /* Profile.json */,
 				99C2930A1B24AE320008C32B /* Mapping */,
 				99C292C01B24AD4A0008C32B /* Supporting Files */,
@@ -215,6 +237,7 @@
 				994243AC1CAA4F3E00B5DB6C /* Profile.swift */,
 				994243AE1CAA4F4D00B5DB6C /* Stats.swift */,
 				993D14D01CAC7D83003CAEE3 /* PhoneNumber.swift */,
+				99BD0D891CBE50EB00995392 /* Mapping */,
 				994243B01CAA502A00B5DB6C /* Profile.json */,
 				99C292F81B24AD5F0008C32B /* Supporting Files */,
 			);
@@ -414,8 +437,10 @@
 			files = (
 				99C292C31B24AD4A0008C32B /* AppDelegate.swift in Sources */,
 				99C293101B24AE320008C32B /* Stats+Arrow.swift in Sources */,
+				999B90681CBE4C2100C4B46A /* User.swift in Sources */,
 				99C2930F1B24AE320008C32B /* Profile+Arrow.swift in Sources */,
 				99C2930E1B24AE320008C32B /* Usage.swift in Sources */,
+				999B906A1CBE4C3D00C4B46A /* User+JSON.swift in Sources */,
 				99C293111B24AE320008C32B /* Models.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -440,8 +465,11 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				99BD0D8D1CBE511A00995392 /* Profile+JSON.swift in Sources */,
+				99BD0D921CBE518D00995392 /* PhoneNumber+JSON.swift in Sources */,
 				99C292FB1B24AD5F0008C32B /* ArrowTests.swift in Sources */,
 				994243AF1CAA4F4D00B5DB6C /* Stats.swift in Sources */,
+				99BD0D8F1CBE514A00995392 /* Stats+JSON.swift in Sources */,
 				994243AD1CAA4F3E00B5DB6C /* Profile.swift in Sources */,
 				993D14D11CAC7D83003CAEE3 /* PhoneNumber.swift in Sources */,
 			);

--- a/ArrowExample/ArrowExample/Mapping/Profile+Arrow.swift
+++ b/ArrowExample/ArrowExample/Mapping/Profile+Arrow.swift
@@ -11,7 +11,7 @@ import Arrow
 
 extension Profile:ArrowParsable {
     
-    init(json: JSON) {
+    mutating func deserialize(json: JSON) {
         identifier <-- json["id"]
         createdAt <-- json["created_at"]
         name <-- json["name"]

--- a/ArrowExample/ArrowExample/Usage.swift
+++ b/ArrowExample/ArrowExample/Usage.swift
@@ -18,7 +18,8 @@ class Usage {
         Arrow.setDateFormat("yyyy-MM-dd'T'HH:mm:ssZZZZZ")
 
         let json:JSON = jsonForName("Profile")!
-        let profile = Profile(json: json)
+        var profile = Profile()
+        profile.deserialize(json)
         print("id : \(profile.identifier)")
         print("created at : \(profile.createdAt)")
         print("name : \(profile.name)")

--- a/ArrowExample/ArrowExample/User+JSON.swift
+++ b/ArrowExample/ArrowExample/User+JSON.swift
@@ -1,0 +1,20 @@
+//
+//  User+JSON.swift
+//  ArrowExample
+//
+//  Created by Sacha Durand Saint Omer on 13/04/16.
+//  Copyright © 2016 Sacha Durand Saint Omer. All rights reserved.
+//
+
+
+import Arrow
+
+extension User:ArrowParsable {
+    
+    public func deserialize(json: JSON) {
+        
+    }
+}
+
+
+//class = not in extension

--- a/ArrowExample/ArrowExample/User.swift
+++ b/ArrowExample/ArrowExample/User.swift
@@ -1,0 +1,14 @@
+//
+//  User.swift
+//  ArrowExample
+//
+//  Created by Sacha Durand Saint Omer on 13/04/16.
+//  Copyright © 2016 Sacha Durand Saint Omer. All rights reserved.
+//
+
+import Foundation
+
+public class User {
+
+    public required init() { }
+}

--- a/ArrowExample/ArrowTests/ArrowTests.swift
+++ b/ArrowExample/ArrowTests/ArrowTests.swift
@@ -20,7 +20,8 @@ class ArrowTests: XCTestCase {
         Arrow.setDateFormat("yyyy-MM-dd'T'HH:mm:ssZZZZZ")
         Arrow.setUseTimeIntervalSinceReferenceDate(true)
         let json:JSON = jsonForName("Profile")!
-        profile = Profile(json: json)
+        profile = Profile()
+        profile?.deserialize(json)
     }
     
     override func tearDown() {

--- a/ArrowExample/ArrowTests/PhoneNumber+JSON.swift
+++ b/ArrowExample/ArrowTests/PhoneNumber+JSON.swift
@@ -1,0 +1,17 @@
+//
+//  PhoneNumber+JSON.swift
+//  ArrowExample
+//
+//  Created by Sacha Durand Saint Omer on 13/04/16.
+//  Copyright © 2016 Sacha Durand Saint Omer. All rights reserved.
+//
+
+import Arrow
+
+extension PhoneNumber: ArrowParsable {
+    
+    mutating func deserialize(json: JSON) {
+        label <-- json["label"]
+        number <-- json["number"]
+    }
+}

--- a/ArrowExample/ArrowTests/PhoneNumber.swift
+++ b/ArrowExample/ArrowTests/PhoneNumber.swift
@@ -12,14 +12,3 @@ struct PhoneNumber {
     var label:String = ""
     var number:String = ""
 }
-
-
-import Arrow
-
-extension PhoneNumber: ArrowParsable {
-    
-    init(json: JSON) {
-        label <-- json["label"]
-        number <-- json["number"]
-    }
-}

--- a/ArrowExample/ArrowTests/Profile+JSON.swift
+++ b/ArrowExample/ArrowTests/Profile+JSON.swift
@@ -1,0 +1,36 @@
+//
+//  Profile+JSON.swift
+//  ArrowExample
+//
+//  Created by Sacha Durand Saint Omer on 13/04/16.
+//  Copyright © 2016 Sacha Durand Saint Omer. All rights reserved.
+//
+
+import Arrow
+
+extension Profile:ArrowParsable {
+    
+    mutating func deserialize(json: JSON) {
+        identifier <-- json["id"]
+        createdAt <-- json["created_at"]
+        name <-- json["name"]
+        optionalName = nil
+        optionalName <-- json["name"]
+        stats <== json["stats"]
+        optionalStats = nil
+        optionalStats <== json["stats"]
+        optionalDate = nil
+        optionalDate <-- json["created_at_timestamp"]
+        phoneNumbers <== json["phoneNumbers"]
+        optionalPhoneNumbers <== json["phoneNumbers"]
+        strings <-- json["strings"]
+        ints <-- json["ints"]
+        bools <-- json["bools"]
+        cgfloat <-- json["float"]
+        float <-- json["float"]
+        double <-- json["double"]
+        cgfloatString <-- json["floatString"]
+        floatString <-- json["floatString"]
+        doubleString <-- json["doubleString"]
+    }
+}

--- a/ArrowExample/ArrowTests/Profile.swift
+++ b/ArrowExample/ArrowTests/Profile.swift
@@ -7,6 +7,7 @@
 //
 
 import Foundation
+import CoreGraphics
 
 struct Profile {
     var identifier = 0
@@ -27,34 +28,4 @@ struct Profile {
     var doubleString:Double = 0.0
     var floatString:CGFloat = 0.0
     var cgfloatString:CGFloat = 0.0
-}
-
-
-import Arrow
-
-extension Profile:ArrowParsable {
-    
-    init(json: JSON) {
-        identifier <-- json["id"]
-        createdAt <-- json["created_at"]
-        name <-- json["name"]
-        optionalName = nil
-        optionalName <-- json["name"]
-        stats <== json["stats"]
-        optionalStats = nil
-        optionalStats <== json["stats"]
-        optionalDate = nil
-        optionalDate <-- json["created_at_timestamp"]
-        phoneNumbers <== json["phoneNumbers"]
-        optionalPhoneNumbers <== json["phoneNumbers"]
-        strings <-- json["strings"]
-        ints <-- json["ints"]
-        bools <-- json["bools"]
-        cgfloat <-- json["float"]
-        float <-- json["float"]
-        double <-- json["double"]
-        cgfloatString <-- json["floatString"]
-        floatString <-- json["floatString"]
-        doubleString <-- json["doubleString"]
-    }
 }

--- a/ArrowExample/ArrowTests/Stats+JSON.swift
+++ b/ArrowExample/ArrowTests/Stats+JSON.swift
@@ -1,12 +1,11 @@
 //
-//  Stats+Arrow.swift
-//  Swift Structs Test
+//  Stats+JSON.swift
+//  ArrowExample
 //
-//  Created by Sacha Durand Saint Omer on 6/7/15.
-//  Copyright (c) 2015 Sacha Durand Saint Omer. All rights reserved.
+//  Created by Sacha Durand Saint Omer on 13/04/16.
+//  Copyright © 2016 Sacha Durand Saint Omer. All rights reserved.
 //
 
-import Foundation
 import Arrow
 
 extension Stats:ArrowParsable {

--- a/ArrowExample/ArrowTests/Stats.swift
+++ b/ArrowExample/ArrowTests/Stats.swift
@@ -14,12 +14,3 @@ struct Stats {
 }
 
 
-import Arrow
-
-extension Stats:ArrowParsable {
-    
-    init(json: JSON) {
-        numberOfFriends <-- json["numberOfFriends"]
-        numberOfFans <-- json["numberOfFans"]
-    }
-}

--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ if let pns = json["phoneNumbers"] as? [AnyObject] {
 ### After  🎉🎉🎉
 ```swift
 extension Profile:ArrowParsable {
-    init(json: JSON) {
+    mutating func deserialize(json: JSON) {
         identifier <-- json["id"]
         name <-- json["name"]
         stats <== json["stats"]
@@ -144,7 +144,7 @@ That's because we created and extension "Stats+Arrow.swift" enabling us to use t
 import Foundation
 
 extension Stats:ArrowParsable {
-    init(json: JSON) {
+    mutating func deserialize(json: JSON) {
         numberOfFriends <-- json["numberOfFriends"]
         numberOfFans <-- json["numberOfFans"]
     }


### PR DESCRIPTION
In order to keep things well separated, The `init(son:JSON)` was supposed to be provided in a Swift extension file.
- With Structs, it is supposed to work but yells a compiler segfault (weirdly when structs contain optional type)
- With classes, the `init(json:JSON)` is `required` and has to be provided inside our class.

This clearly **violates** our desire to separate the JSON parsing logic from the plain swift Object.

The proposed solution is the following :

Transform `init(son:JSON)` into `func deserialize(json: JSON)`, the latter will be `mutating` for structs and plain for classes. 

Arrow still requires you to have a plain `init()` method but no longer the `JSON` version. (It needs to know how to build your models obviously).

@maxkonovalov I have tested in my project and it seems to work fine, and solves the issue explained above. I would love your feedback on this since it is a breaking change, that will require bumping version number to 1.0.0

Thanks a lot in advance,
