### PR TITLE
Escape url string because NSURL doesn't do it.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,7 @@ DerivedData
 *.hmap
 *.ipa
 *.xcuserstate
+.DS_Store
 
 # CocoaPods
 #

--- a/ArrowTests/ArrowTests.swift
+++ b/ArrowTests/ArrowTests.swift
@@ -35,11 +35,27 @@ class ArrowTests: XCTestCase {
     }
     
     func testParsingURL() {
-        XCTAssertEqual(profile!.link.absoluteString, "https://apple.com/steve")
+        XCTAssertEqual(profile!.link.absoluteString.stringByRemovingPercentEncoding, "https://apple.com/steve")
     }
     
     func testParsingOptionalURL() {
-        XCTAssertEqual(profile!.optionalLink!.absoluteString, "https://apple.com/steve")
+        XCTAssertEqual(profile!.optionalLink!.absoluteString.stringByRemovingPercentEncoding, "https://apple.com/steve")
+    }
+    
+    func testParsingEmojiURL() {
+        XCTAssertEqual(profile!.emojiLink.absoluteString.stringByRemovingPercentEncoding, "http://🆒🔗.ws")
+    }
+    
+    func testParsingOptionalEmojiURL() {
+        XCTAssertEqual(profile!.optionalEmojiLink!.absoluteString.stringByRemovingPercentEncoding, "http://🆒🔗.ws")
+    }
+    
+    func testParsingAccentURL() {
+        XCTAssertEqual(profile!.accentLink.absoluteString.stringByRemovingPercentEncoding, "http://gégé.com")
+    }
+    
+    func testParsingOptionalAccentURL() {
+        XCTAssertEqual(profile!.optionalAccentLink!.absoluteString.stringByRemovingPercentEncoding, "http://gégé.com")
     }
 
     func testParsingDate() {

--- a/ArrowTests/Profile.json
+++ b/ArrowTests/Profile.json
@@ -3,6 +3,8 @@
     "weekdayInt" : 3,
     "difficulty": "High",
     "link": "https://apple.com/steve",
+    "emoji_link": "http://🆒🔗.ws",
+    "accent_link": "http://gégé.com",
     "created_at" : "2013-06-07T16:38:40+02:00",
     "created_at_timestamp" : "392308720",
     "name": "Francky",

--- a/ArrowTests/Profile.swift
+++ b/ArrowTests/Profile.swift
@@ -29,6 +29,10 @@ struct Profile {
     var identifier = 0
     var link = NSURL()
     var optionalLink:NSURL?
+    var emojiLink = NSURL()
+    var optionalEmojiLink:NSURL?
+    var accentLink = NSURL()
+    var optionalAccentLink:NSURL?
     var createdAt = NSDate()
     var name = ""
     var optionalName:String?

--- a/ArrowTests/mapping/Profile+JSON.swift
+++ b/ArrowTests/mapping/Profile+JSON.swift
@@ -14,6 +14,10 @@ extension Profile:ArrowParsable {
         identifier <-- json["id"]
         link <-- json["link"]
         optionalLink <-- json["link"]
+        emojiLink <-- json["emoji_link"]
+        optionalEmojiLink <-- json["emoji_link"]
+        accentLink <-- json["accent_link"]
+        optionalAccentLink <-- json["accent_link"]
         createdAt <-- json["created_at"]?.dateFormat("yyyy-MM-dd'T'HH:mm:ssZZZZZ")
         name <-- json["name"]
         optionalName = nil

--- a/Source/Arrow.swift
+++ b/Source/Arrow.swift
@@ -175,7 +175,7 @@ public func <-- (inout left: NSURL?, right: JSON?) {
 func parseURL(inout left:NSURL?, right:JSON?) {
     var str = ""
     str <-- right
-    if let url = NSURL(string:str) {
+    if let escapedStr = str.stringByAddingPercentEncodingWithAllowedCharacters(NSCharacterSet.URLQueryAllowedCharacterSet()), let url = NSURL(string:escapedStr) {
         left = url
     }
 }


### PR DESCRIPTION
I found that NSURL(string) didn't escape the string so valid url with accent or emoji will return nil.
Let me know if you find it helpful for Arrow ;)
