### PR TITLE
Add opeartor precedence group

### DIFF
--- a/Source/Arrow.swift
+++ b/Source/Arrow.swift
@@ -86,7 +86,7 @@ public class Arrow {
 
 // MARK: - Parse Default swift Types
 
-infix operator <--
+infix operator <-- : AssignmentPrecedence
 
 public func <-- <T>(left: inout T, right: JSON?) {
     setLeftIfIsResultNonNil(left: &left, right: right, function: parseType)


### PR DESCRIPTION
Added `AssignmentPrecedence` group for `<--` operator.

Info on current swift operators precedence here: https://github.com/apple/swift-evolution/blob/master/proposals/0077-operator-precedence.md#standard-library-changes